### PR TITLE
[1. 로그인 구현] 이승철 과제 제출합니다.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,20 +30,33 @@ issue 1. 로그인 구현
       5. memberService.join 의 validate 로직 수정 -> validateDuplicateMember에 email 중복 확인 코드 추가
       6. members/memberList.html 수정 -> email, password 추가
       
-
-
-
-
----------
 2. 홈 화면
    1. Path: /
    2. 로그인 버튼 추가
    3. 클릭 -> /members/login 으로 이동
+      => home.html 수정 -> 로그인 버튼 추가(/members/login 으로 보내기)
+   
 3. 로그인 페이지
    1. Path: /members/login
+      1. LoginController 생성 -> @GetMapping("/members/login") 함수 만들어서 loginForm.html과 바인딩
+      2. loginForm.html 생성
+   
+
    2. 성공 -> 블로그 리스트 페이지(/blogs?creatorId=1)
       실패 -> 홈(/)
+      1. memberService에 login 함수 만들기 
+      2. memberService에 validateLogin 함수 만들기
+         1. findByEmail해서 null X
+         2. password 가 일치
+      3. LoginController에 post 방식의 login하는 함수 , 데이터 받아올 form 생성 
+         1. memberService.login 활용
+         2. 성공시 /blogs?creatorId='id'
+         3. 실패시 redirect
    3. loginForm.html
+
+   ---------------------------
+
+
 4. 블로그 페이지
    1. Path: /blogs
       Title: ${name}의 블로그

--- a/README.md
+++ b/README.md
@@ -15,3 +15,36 @@
    - 이세원: sewon
    - 이승철: seungcheol
    - 임주민: jumin
+
+### 기능 구현
+issue 1. 로그인 구현
+
+회원가입 된 회원 정보로 로그인 구현
+
+1. 회원가입 필드 추가
+   1. 이메일 / 패스워드 추가 
+      1. members/createMemberForm.html 수정 -> email, password 추가
+      2. memberForm 객체 수정 -> email, password 추가
+      3. member 객체 수정 -> email, password 추가, 생성자 수정(id를 제외하고 객체 생성), set 함수 삭제
+      4. memberController.create 함수 수정 -> 객체 생성 수정
+      5. memberService.join 의 validate 로직 수정 -> validateDuplicateMember에 email 중복 확인 코드 추가
+      6. members/memberList.html 수정 -> email, password 추가
+      
+
+
+
+
+---------
+2. 홈 화면
+   1. Path: /
+   2. 로그인 버튼 추가
+   3. 클릭 -> /members/login 으로 이동
+3. 로그인 페이지
+   1. Path: /members/login
+   2. 성공 -> 블로그 리스트 페이지(/blogs?creatorId=1)
+      실패 -> 홈(/)
+   3. loginForm.html
+4. 블로그 페이지
+   1. Path: /blogs
+      Title: ${name}의 블로그
+5. unit test 추가

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ issue 1. 로그인 구현
          2. password 가 일치
       3. LoginController에 post 방식의 login하는 함수 , 데이터 받아올 form 생성 
          1. memberService.login 활용
-         2. 성공시 /blogs?creatorId='id'
-         3. 실패시 redirect
+         2. 성공시 redirect:/blogs?creatorId='id'
+         3. 실패시 redirect:/
    3. loginForm.html
 
    ---------------------------
@@ -60,4 +60,6 @@ issue 1. 로그인 구현
 4. 블로그 페이지
    1. Path: /blogs
       Title: ${name}의 블로그
+      1. blogController 추가
+      2. ....
 5. unit test 추가

--- a/README.md
+++ b/README.md
@@ -50,16 +50,18 @@ issue 1. 로그인 구현
          2. password 가 일치
       3. LoginController에 post 방식의 login하는 함수 , 데이터 받아올 form 생성 
          1. memberService.login 활용
-         2. 성공시 redirect:/blogs?creatorId='id'
+         2. 성공시 redirect:/blogs
          3. 실패시 redirect:/
    3. loginForm.html
-
-   ---------------------------
 
 
 4. 블로그 페이지
    1. Path: /blogs
       Title: ${name}의 블로그
-      1. blogController 추가
-      2. ....
+      1. blogController 추가 (MemberRepository 의존)
+         1. blogForm : parameter로 creatorId를 받아옴. name을 찾고, model에 주입해 blogs/blogList.html과 바인딩
+      
 5. unit test 추가
+   1. LoginServiceTest : 추가(정상수행, 이메일 존재 X, 비밀번호 불일치 예외)
+   2. MemberServiceTest : "중복_이메일_예외" 추가
+   3. MemoryMemberRepositoryTest : 객체 생성 방법 수정(memberForm을 생성자에 주입), findById 추가

--- a/src/main/java/com/landvibe/landlog/controller/BlogController.java
+++ b/src/main/java/com/landvibe/landlog/controller/BlogController.java
@@ -1,0 +1,27 @@
+package com.landvibe.landlog.controller;
+
+import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.service.MemberService;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Optional;
+
+@Controller
+public class BlogController {
+
+    private final MemberService memberService;
+
+    public BlogController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/blogs")
+    public String blogForm(@RequestParam("creatorId") Long creatorId, Model model) {
+        Optional<Member> member = memberService.findOne(creatorId);
+        model.addAttribute("name", member.get().getName());
+        return "blogs/blogList";
+    }
+}

--- a/src/main/java/com/landvibe/landlog/controller/BlogController.java
+++ b/src/main/java/com/landvibe/landlog/controller/BlogController.java
@@ -21,6 +21,11 @@ public class BlogController {
     @GetMapping("/blogs")
     public String blogForm(@RequestParam("creatorId") Long creatorId, Model model) {
         Optional<Member> member = memberService.findOne(creatorId);
+
+        if (member.isEmpty()) {
+            return "redirect:/";
+        }
+
         model.addAttribute("name", member.get().getName());
         return "blogs/blogList";
     }

--- a/src/main/java/com/landvibe/landlog/controller/BlogController.java
+++ b/src/main/java/com/landvibe/landlog/controller/BlogController.java
@@ -20,7 +20,7 @@ public class BlogController {
 
     @GetMapping("/blogs")
     public String blogForm(@RequestParam("creatorId") Long creatorId, Model model) {
-        Optional<Member> member = memberService.findOne(creatorId);
+        Optional<Member> member = memberService.findOneById(creatorId);
 
         if (member.isEmpty()) {
             return "redirect:/";

--- a/src/main/java/com/landvibe/landlog/controller/LoginController.java
+++ b/src/main/java/com/landvibe/landlog/controller/LoginController.java
@@ -29,8 +29,8 @@ public class LoginController {
             return "redirect:/";
         }
 
-        redirectAttributes.addAttribute("createId", memberId);
-        return "redirect:/blogs/{creatorId}";
+        redirectAttributes.addAttribute("creatorId", memberId);
+        return "redirect:/blogs";
     }
 
 }

--- a/src/main/java/com/landvibe/landlog/controller/LoginController.java
+++ b/src/main/java/com/landvibe/landlog/controller/LoginController.java
@@ -1,17 +1,36 @@
 package com.landvibe.landlog.controller;
 
+import com.landvibe.landlog.service.LoginService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 @Controller
 public class LoginController {
 
+    private final LoginService loginService;
+
+    public LoginController(LoginService loginService) {
+        this.loginService = loginService;
+    }
+
     @GetMapping("/members/login")
-    public String loginForm(){
+    public String loginForm() {
         return "members/loginForm";
     }
 
+    @PostMapping("/members/login")
+    public String login(LoginForm loginForm, RedirectAttributes redirectAttributes) {
+        Long memberId;
+        try {
+            memberId = loginService.login(loginForm);
+        } catch (IllegalArgumentException e) {
+            return "redirect:/";
+        }
 
+        redirectAttributes.addAttribute("createId", memberId);
+        return "redirect:/blogs/{creatorId}";
+    }
 
 }

--- a/src/main/java/com/landvibe/landlog/controller/LoginController.java
+++ b/src/main/java/com/landvibe/landlog/controller/LoginController.java
@@ -25,12 +25,12 @@ public class LoginController {
         Long memberId;
         try {
             memberId = loginService.login(loginForm);
+            redirectAttributes.addAttribute("creatorId", memberId);
+            return "redirect:/blogs";
+
         } catch (IllegalArgumentException e) {
             return "redirect:/";
         }
-
-        redirectAttributes.addAttribute("creatorId", memberId);
-        return "redirect:/blogs";
     }
 
 }

--- a/src/main/java/com/landvibe/landlog/controller/LoginController.java
+++ b/src/main/java/com/landvibe/landlog/controller/LoginController.java
@@ -1,0 +1,17 @@
+package com.landvibe.landlog.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class LoginController {
+
+    @GetMapping("/members/login")
+    public String loginForm(){
+        return "members/loginForm";
+    }
+
+
+
+}

--- a/src/main/java/com/landvibe/landlog/controller/LoginController.java
+++ b/src/main/java/com/landvibe/landlog/controller/LoginController.java
@@ -28,7 +28,7 @@ public class LoginController {
             redirectAttributes.addAttribute("creatorId", memberId);
             return "redirect:/blogs";
 
-        } catch (IllegalArgumentException e) {
+        } catch (RuntimeException e) {
             return "redirect:/";
         }
     }

--- a/src/main/java/com/landvibe/landlog/controller/LoginForm.java
+++ b/src/main/java/com/landvibe/landlog/controller/LoginForm.java
@@ -1,0 +1,19 @@
+package com.landvibe.landlog.controller;
+
+public class LoginForm {
+    private final String email;
+    private final String password;
+
+    public LoginForm(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/com/landvibe/landlog/controller/MemberController.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberController.java
@@ -7,7 +7,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Controller

--- a/src/main/java/com/landvibe/landlog/controller/MemberController.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberController.java
@@ -25,8 +25,7 @@ public class MemberController {
 
     @PostMapping(value = "/members/new")
     public String create(MemberForm form) {
-        Member member = new Member();
-        member.setName(form.getName());
+        Member member = new Member(form.getName(), form.getEmail(), form.getPassword());
         memberService.join(member);
         return "redirect:/";
     }

--- a/src/main/java/com/landvibe/landlog/controller/MemberController.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberController.java
@@ -25,7 +25,7 @@ public class MemberController {
 
     @PostMapping(value = "/members/new")
     public String create(MemberForm form) {
-        Member member = new Member(form.getName(), form.getEmail(), form.getPassword());
+        Member member = new Member(form);
         memberService.join(member);
         return "redirect:/";
     }

--- a/src/main/java/com/landvibe/landlog/controller/MemberController.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberController.java
@@ -7,6 +7,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Controller

--- a/src/main/java/com/landvibe/landlog/controller/MemberController.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberController.java
@@ -24,7 +24,7 @@ public class MemberController {
 
     @PostMapping(value = "/members/new")
     public String create(MemberForm form) {
-        Member member = new Member(form);
+        Member member = new Member(form.getName(), form.getEmail(), form.getPassword());
         memberService.join(member);
         return "redirect:/";
     }

--- a/src/main/java/com/landvibe/landlog/controller/MemberForm.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberForm.java
@@ -1,9 +1,15 @@
 package com.landvibe.landlog.controller;
 
 public class MemberForm {
-    private String name;
-    private String email;
-    private String password;
+    private final String name;
+    private final String email;
+    private final String password;
+
+    public MemberForm(String name, String email, String password) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
 
     public String getName() {
         return name;

--- a/src/main/java/com/landvibe/landlog/controller/MemberForm.java
+++ b/src/main/java/com/landvibe/landlog/controller/MemberForm.java
@@ -2,12 +2,18 @@ package com.landvibe.landlog.controller;
 
 public class MemberForm {
     private String name;
+    private String email;
+    private String password;
 
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }

--- a/src/main/java/com/landvibe/landlog/domain/Member.java
+++ b/src/main/java/com/landvibe/landlog/domain/Member.java
@@ -1,7 +1,4 @@
 package com.landvibe.landlog.domain;
-
-import com.landvibe.landlog.controller.MemberForm;
-
 public class Member {
 
     private Long id;
@@ -9,13 +6,10 @@ public class Member {
     private String email;
     private String password;
 
-    public Member() {
-    }
-
-    public Member(MemberForm memberForm) {
-        this.name = memberForm.getName();
-        this.email = memberForm.getEmail();
-        this.password = memberForm.getPassword();
+    public Member(String name, String email, String password) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
     }
 
     public void setId(Long id) {

--- a/src/main/java/com/landvibe/landlog/domain/Member.java
+++ b/src/main/java/com/landvibe/landlog/domain/Member.java
@@ -1,5 +1,7 @@
 package com.landvibe.landlog.domain;
 
+import com.landvibe.landlog.controller.MemberForm;
+
 public class Member {
 
     private Long id;
@@ -7,14 +9,13 @@ public class Member {
     private String email;
     private String password;
 
-
     public Member() {
     }
 
-    public Member(String name, String email, String password) {
-        this.name = name;
-        this.email = email;
-        this.password = password;
+    public Member(MemberForm memberForm) {
+        this.name = memberForm.getName();
+        this.email = memberForm.getEmail();
+        this.password = memberForm.getPassword();
     }
 
     public void setId(Long id) {

--- a/src/main/java/com/landvibe/landlog/domain/Member.java
+++ b/src/main/java/com/landvibe/landlog/domain/Member.java
@@ -4,28 +4,36 @@ public class Member {
 
     private Long id;
     private String name;
+    private String email;
+    private String password;
+
 
     public Member() {
     }
 
-    public Member(Long id, String name) {
-        this.id = id;
+    public Member(String name, String email, String password) {
         this.name = name;
-    }
-
-    public Long getId() {
-        return id;
+        this.email = email;
+        this.password = password;
     }
 
     public void setId(Long id) {
         this.id = id;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
     }
 }

--- a/src/main/java/com/landvibe/landlog/exception/DuplicatedEmailException.java
+++ b/src/main/java/com/landvibe/landlog/exception/DuplicatedEmailException.java
@@ -1,0 +1,7 @@
+package com.landvibe.landlog.exception;
+
+public class DuplicatedEmailException extends RuntimeException {
+    public DuplicatedEmailException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/landvibe/landlog/exception/DuplicatedNameException.java
+++ b/src/main/java/com/landvibe/landlog/exception/DuplicatedNameException.java
@@ -1,0 +1,7 @@
+package com.landvibe.landlog.exception;
+
+public class DuplicatedNameException extends RuntimeException {
+    public DuplicatedNameException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/landvibe/landlog/exception/InvalidEmailException.java
+++ b/src/main/java/com/landvibe/landlog/exception/InvalidEmailException.java
@@ -1,0 +1,9 @@
+package com.landvibe.landlog.exception;
+
+public class InvalidEmailException extends RuntimeException {
+    public InvalidEmailException(String message) {
+        super(message);
+    }
+}
+
+

--- a/src/main/java/com/landvibe/landlog/exception/PasswordMismatchException.java
+++ b/src/main/java/com/landvibe/landlog/exception/PasswordMismatchException.java
@@ -1,0 +1,7 @@
+package com.landvibe.landlog.exception;
+
+public class PasswordMismatchException extends RuntimeException {
+    public PasswordMismatchException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/landvibe/landlog/repository/MemberRepository.java
+++ b/src/main/java/com/landvibe/landlog/repository/MemberRepository.java
@@ -13,7 +13,7 @@ public interface MemberRepository {
 
     Optional<Member> findByName(String name);
 
-    Optional<Member> findByEmail(String name);
+    Optional<Member> findByEmail(String email);
 
     List<Member> findAll();
 }

--- a/src/main/java/com/landvibe/landlog/repository/MemberRepository.java
+++ b/src/main/java/com/landvibe/landlog/repository/MemberRepository.java
@@ -13,5 +13,7 @@ public interface MemberRepository {
 
     Optional<Member> findByName(String name);
 
+    Optional<Member> findByEmail(String name);
+
     List<Member> findAll();
 }

--- a/src/main/java/com/landvibe/landlog/repository/MemoryMemberRepository.java
+++ b/src/main/java/com/landvibe/landlog/repository/MemoryMemberRepository.java
@@ -31,6 +31,13 @@ public class MemoryMemberRepository implements MemberRepository {
     }
 
     @Override
+    public Optional<Member> findByEmail(String email) {
+        return store.values().stream()
+                .filter(member -> member.getEmail().equals(email))
+                .findAny();
+    }
+
+    @Override
     public List<Member> findAll() {
         return new ArrayList<>(store.values());
     }

--- a/src/main/java/com/landvibe/landlog/service/LoginService.java
+++ b/src/main/java/com/landvibe/landlog/service/LoginService.java
@@ -2,6 +2,8 @@ package com.landvibe.landlog.service;
 
 import com.landvibe.landlog.controller.LoginForm;
 import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.exception.InvalidEmailException;
+import com.landvibe.landlog.exception.PasswordMismatchException;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -15,20 +17,20 @@ public class LoginService {
         this.memberService = memberService;
     }
 
-    public Long login(LoginForm loginForm) throws IllegalArgumentException {
+    public Long login(LoginForm loginForm) throws RuntimeException {
         Optional<Member> member = memberService.findOneByEmail(loginForm.getEmail());
         validateLogin(member, loginForm);
 
         return member.get().getId();
     }
 
-    private void validateLogin(Optional<Member> member, LoginForm loginForm) throws IllegalArgumentException {
-        checkPassword(member.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다.")), loginForm);
+    private void validateLogin(Optional<Member> member, LoginForm loginForm) throws RuntimeException {
+        checkPassword(member.orElseThrow(() -> new InvalidEmailException("존재하지 않는 이메일입니다.")), loginForm);
     }
 
     private void checkPassword(Member member, LoginForm loginForm) {
         if (!member.getPassword().equals(loginForm.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new PasswordMismatchException("비밀번호가 일치하지 않습니다.");
         }
     }
 }

--- a/src/main/java/com/landvibe/landlog/service/LoginService.java
+++ b/src/main/java/com/landvibe/landlog/service/LoginService.java
@@ -3,7 +3,6 @@ package com.landvibe.landlog.service;
 import com.landvibe.landlog.controller.LoginForm;
 import com.landvibe.landlog.domain.Member;
 import com.landvibe.landlog.repository.MemberRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -19,20 +18,15 @@ public class LoginService {
 
     public Long login(LoginForm loginForm) throws IllegalArgumentException {
         Optional<Member> member = memberRepository.findByEmail(loginForm.getEmail());
-        Member validMember = validateLogin(member, loginForm);
+        validateLogin(member, loginForm);
 
-        return validMember.getId();
+        return member.get().getId();
     }
 
-    private Member validateLogin(Optional<Member> member, LoginForm loginForm) {
-        Member validMember = member.orElseThrow(() -> {
-            throw new IllegalArgumentException("존재하지 않는 이메일 입니다.");
-        });
-
-        if (!validMember.getPassword().equals(loginForm.getPassword())) {
+    private void validateLogin(Optional<Member> member, LoginForm loginForm) {
+        if (!member.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."))
+                .getPassword().equals(loginForm.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
-
-        return validMember;
     }
 }

--- a/src/main/java/com/landvibe/landlog/service/LoginService.java
+++ b/src/main/java/com/landvibe/landlog/service/LoginService.java
@@ -1,0 +1,39 @@
+package com.landvibe.landlog.service;
+
+import com.landvibe.landlog.controller.LoginForm;
+import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class LoginService {
+
+    private final MemberRepository memberRepository;
+
+    @Autowired // 생략 가능
+    public LoginService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    public Long login(LoginForm loginForm) throws IllegalArgumentException {
+        validateLogin(loginForm);
+        return memberRepository.findByEmail(loginForm.getEmail()).get().getId();
+    }
+
+    private void validateLogin(LoginForm loginForm) {
+        Optional<Member> member = memberRepository.findByEmail(loginForm.getEmail());
+
+        if (member.isEmpty()) {
+            throw new IllegalArgumentException("존재하지 않는 이메일 입니다.");
+        }
+
+        member.ifPresent(m -> {
+            if (!m.getPassword().equals(loginForm.getPassword())) {
+                throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            }
+        });
+    }
+}

--- a/src/main/java/com/landvibe/landlog/service/LoginService.java
+++ b/src/main/java/com/landvibe/landlog/service/LoginService.java
@@ -2,7 +2,6 @@ package com.landvibe.landlog.service;
 
 import com.landvibe.landlog.controller.LoginForm;
 import com.landvibe.landlog.domain.Member;
-import com.landvibe.landlog.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -10,22 +9,25 @@ import java.util.Optional;
 @Service
 public class LoginService {
 
-    private final MemberRepository memberRepository;
+    private final MemberService memberService;
 
-    public LoginService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
+    public LoginService(MemberService memberService) {
+        this.memberService = memberService;
     }
 
     public Long login(LoginForm loginForm) throws IllegalArgumentException {
-        Optional<Member> member = memberRepository.findByEmail(loginForm.getEmail());
+        Optional<Member> member = memberService.findOneByEmail(loginForm.getEmail());
         validateLogin(member, loginForm);
 
         return member.get().getId();
     }
 
-    private void validateLogin(Optional<Member> member, LoginForm loginForm) {
-        if (!member.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."))
-                .getPassword().equals(loginForm.getPassword())) {
+    private void validateLogin(Optional<Member> member, LoginForm loginForm) throws IllegalArgumentException {
+        checkPassword(member.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다.")), loginForm);
+    }
+
+    private void checkPassword(Member member, LoginForm loginForm) {
+        if (!member.getPassword().equals(loginForm.getPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
     }

--- a/src/main/java/com/landvibe/landlog/service/LoginService.java
+++ b/src/main/java/com/landvibe/landlog/service/LoginService.java
@@ -13,27 +13,26 @@ public class LoginService {
 
     private final MemberRepository memberRepository;
 
-    @Autowired // 생략 가능
     public LoginService(MemberRepository memberRepository) {
         this.memberRepository = memberRepository;
     }
 
     public Long login(LoginForm loginForm) throws IllegalArgumentException {
-        validateLogin(loginForm);
-        return memberRepository.findByEmail(loginForm.getEmail()).get().getId();
+        Optional<Member> member = memberRepository.findByEmail(loginForm.getEmail());
+        Member validMember = validateLogin(member, loginForm);
+
+        return validMember.getId();
     }
 
-    private void validateLogin(LoginForm loginForm) {
-        Optional<Member> member = memberRepository.findByEmail(loginForm.getEmail());
-
-        if (member.isEmpty()) {
+    private Member validateLogin(Optional<Member> member, LoginForm loginForm) {
+        Member validMember = member.orElseThrow(() -> {
             throw new IllegalArgumentException("존재하지 않는 이메일 입니다.");
+        });
+
+        if (!validMember.getPassword().equals(loginForm.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        member.ifPresent(m -> {
-            if (!m.getPassword().equals(loginForm.getPassword())) {
-                throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
-            }
-        });
+        return validMember;
     }
 }

--- a/src/main/java/com/landvibe/landlog/service/MemberService.java
+++ b/src/main/java/com/landvibe/landlog/service/MemberService.java
@@ -24,7 +24,12 @@ public class MemberService {
     private void validateDuplicateMember(Member member) {
         memberRepository.findByName(member.getName())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("이미 존재하는 회원입니다.");
+                    throw new IllegalStateException("이미 존재하는 이름입니다.");
+                });
+
+        memberRepository.findByEmail(member.getEmail())
+                .ifPresent(m -> {
+                    throw new IllegalStateException("이미 존재하는 email 입니다.");
                 });
     }
 

--- a/src/main/java/com/landvibe/landlog/service/MemberService.java
+++ b/src/main/java/com/landvibe/landlog/service/MemberService.java
@@ -37,7 +37,11 @@ public class MemberService {
         return memberRepository.findAll();
     }
 
-    public Optional<Member> findOne(Long memberId) {
+    public Optional<Member> findOneById(Long memberId) {
         return memberRepository.findById(memberId);
+    }
+
+    public Optional<Member> findOneByEmail(String memberEmail) {
+        return memberRepository.findByEmail(memberEmail);
     }
 }

--- a/src/main/java/com/landvibe/landlog/service/MemberService.java
+++ b/src/main/java/com/landvibe/landlog/service/MemberService.java
@@ -29,7 +29,7 @@ public class MemberService {
 
         memberRepository.findByEmail(member.getEmail())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("이미 존재하는 email 입니다."); // 에러 클래스 직접 만들어보기 ?
+                    throw new IllegalStateException("이미 존재하는 이메일입니다."); // 에러 클래스 직접 만들어보기 ?
                 });
     }
 

--- a/src/main/java/com/landvibe/landlog/service/MemberService.java
+++ b/src/main/java/com/landvibe/landlog/service/MemberService.java
@@ -1,6 +1,8 @@
 package com.landvibe.landlog.service;
 
 import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.exception.DuplicatedEmailException;
+import com.landvibe.landlog.exception.DuplicatedNameException;
 import com.landvibe.landlog.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 
@@ -15,7 +17,7 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
-    public Long join(Member member) {
+    public Long join(Member member) throws RuntimeException {
         validateDuplicateMember(member); //중복 회원 검증
         memberRepository.save(member);
         return member.getId();
@@ -24,12 +26,12 @@ public class MemberService {
     private void validateDuplicateMember(Member member) {
         memberRepository.findByName(member.getName())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("이미 존재하는 이름입니다."); // 에러 클래스 직접 만들어보기 ?
+                    throw new DuplicatedNameException("이미 존재하는 이름입니다.");
                 });
 
         memberRepository.findByEmail(member.getEmail())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("이미 존재하는 이메일입니다."); // 에러 클래스 직접 만들어보기 ?
+                    throw new DuplicatedEmailException("이미 존재하는 이메일입니다.");
                 });
     }
 

--- a/src/main/java/com/landvibe/landlog/service/MemberService.java
+++ b/src/main/java/com/landvibe/landlog/service/MemberService.java
@@ -24,12 +24,12 @@ public class MemberService {
     private void validateDuplicateMember(Member member) {
         memberRepository.findByName(member.getName())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("이미 존재하는 이름입니다.");
+                    throw new IllegalStateException("이미 존재하는 이름입니다."); // 에러 클래스 직접 만들어보기 ?
                 });
 
         memberRepository.findByEmail(member.getEmail())
                 .ifPresent(m -> {
-                    throw new IllegalStateException("이미 존재하는 email 입니다.");
+                    throw new IllegalStateException("이미 존재하는 email 입니다."); // 에러 클래스 직접 만들어보기 ?
                 });
     }
 

--- a/src/main/resources/templates/blogs/blogList.html
+++ b/src/main/resources/templates/blogs/blogList.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div class="container">
+    <div>
+        <h1><span th:text="${name}"/>의 블로그</h1>
+    </div>
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -6,6 +6,7 @@
         <h1>Hello Spring</h1>
         <p>회원 기능</p>
         <p>
+            <a href="/members/login">로그인</a>
             <a href="/members/new">회원 가입</a>
             <a href="/members">회원 목록</a>
         </p>

--- a/src/main/resources/templates/members/createMemberForm.html
+++ b/src/main/resources/templates/members/createMemberForm.html
@@ -6,6 +6,10 @@
         <div class="form-group">
             <label for="name">이름</label>
             <input type="text" id="name" name="name" placeholder="이름을 입력하세요">
+            <label for="name">이메일</label>
+            <input type="text" id="email" name="email" placeholder="이메일을 입력하세요">
+            <label for="name">비밀번호</label>
+            <input type="text" id="password" name="password" placeholder="비밀번호를 입력하세요">
         </div>
         <button type="submit">등록</button>
     </form>

--- a/src/main/resources/templates/members/loginForm.html
+++ b/src/main/resources/templates/members/loginForm.html
@@ -1,0 +1,18 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+<div class="container">
+    <form action="/members/login" method="post">
+        <div class="form-group">
+            <label for="email">이메일</label>
+            <input type="text" id="email" name="email" placeholder="이메일을 입력하세요">
+        </div>
+        <div class="form-group">
+            <label for="password">비밀번호</label>
+            <input type="text" id="password" name="password" placeholder="비밀번호를 입력하세요">
+        </div>
+        <button type="submit">로그인</button>
+    </form>
+</div> <!-- /container -->
+</body>
+</html>

--- a/src/main/resources/templates/members/memberList.html
+++ b/src/main/resources/templates/members/memberList.html
@@ -8,12 +8,16 @@
             <tr>
                 <th>#</th>
                 <th>이름</th>
+                <th>이메일</th>
+                <th>비밀번호</th>
             </tr>
             </thead>
             <tbody>
             <tr th:each="member : ${members}">
                 <td th:text="${member.id}"></td>
                 <td th:text="${member.name}"></td>
+                <td th:text="${member.email}"></td>
+                <td th:text="${member.password}"></td>
             </tr>
             </tbody>
         </table>

--- a/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
+++ b/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -15,15 +14,13 @@ class MemoryMemberRepositoryTest {
 
     MemoryMemberRepository repository;
 
-    //member1
-    String name1 = "spring1";
-    String email1 = "spring1@spring.com";
-    String password1 = "1234";
+    String name = "a";
+    String email = "a@spring.com";
+    String password = "1234";
 
-    //member2
-    String name2 = "spring2";
-    String email2 = "spring2@spring.com";
-    String password2 = "1234";
+    String secondName = "b";
+    String secondEmail = "b@spring.com";
+    String secondPassword = "1234";
 
     @BeforeEach
     public void beforeEach() {
@@ -38,7 +35,7 @@ class MemoryMemberRepositoryTest {
     @Test
     void save() {
         //given
-        Member member = new Member(name1, email1, password1);
+        Member member = new Member(name, email, password);
 
         //when
         repository.save(member);
@@ -51,59 +48,64 @@ class MemoryMemberRepositoryTest {
     @Test
     public void findByName() {
         //given
-        Member member1 = new Member(name1, email1, password1);
-        repository.save(member1);
-        Member member2 = new Member(name2, email2, password2);
-        repository.save(member2);
+        Member member = new Member(name, email, password);
+        repository.save(member);
+
+        Member secondMember = new Member(secondName, secondEmail, secondPassword);
+        repository.save(secondMember);
 
         //when
-        Member result = repository.findByName("spring1").get();
+        Member result = repository.findByName(member.getName()).get();
 
         //then
-        assertThat(result).isEqualTo(member1);
+        assertThat(member).isEqualTo(result);
     }
 
     @Test
     public void findByEmail() {
         //given
-        Member member1 = new Member(name1, email1, password1);
-        repository.save(member1);
-        Member member2 = new Member(name2, email2, password2);
-        repository.save(member2);
+        Member member = new Member(name, email, password);
+        repository.save(member);
+
+        Member secondMember = new Member(secondName, secondEmail, secondPassword);
+        repository.save(secondMember);
 
         //when
-        Member result = repository.findByEmail("spring1@spring.com").get();
+        Member result = repository.findByEmail(member.getEmail()).get();
 
         //then
-        assertThat(result).isEqualTo(member1);
+        assertThat(member).isEqualTo(result);
     }
 
 
     @Test
     public void findAll() {
         //given
-        Member member1 = new Member(name1, email1, password1);
-        repository.save(member1);
-        Member member2 = new Member(name2, email2, password2);
-        repository.save(member2);
+        Member member = new Member(name, email, password);
+        repository.save(member);
+
+        Member secondMember = new Member(secondName, secondEmail, secondPassword);
+        repository.save(secondMember);
+
+        int expectedSize = 2;
 
         //when
         List<Member> result = repository.findAll();
 
         //then
-        assertThat(result.size()).isEqualTo(2);
+        assertThat(result.size()).isEqualTo(expectedSize);
     }
 
     @Test
     public void findById() {
         //given
-        Member member1 = new Member(name1, email1, password1);
-        repository.save(member1);
+        Member member = new Member(name, email, password);
+        repository.save(member);
 
         //when
-        Optional<Member> actual = repository.findById(member1.getId());
+        Member result = repository.findById(member.getId()).get();
 
         //then
-        Assertions.assertThat(actual.get()).isEqualTo(member1);
+        Assertions.assertThat(result).isEqualTo(member);
     }
 }

--- a/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
+++ b/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
@@ -6,8 +6,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MemoryMemberRepositoryTest {
@@ -17,14 +15,12 @@ class MemoryMemberRepositoryTest {
     String name = "a";
     String email = "a@spring.com";
     String password = "1234";
-
-    String secondName = "b";
-    String secondEmail = "b@spring.com";
-    String secondPassword = "1234";
+    Member member = new Member(name, email, password);
 
     @BeforeEach
     public void beforeEach() {
         repository = new MemoryMemberRepository();
+        repository.save(member);
     }
 
     @AfterEach
@@ -33,29 +29,9 @@ class MemoryMemberRepositoryTest {
     }
 
     @Test
-    void save() {
-        //given
-        Member member = new Member(name, email, password);
-
-        //when
-        repository.save(member);
-
-        //then
-        Member result = repository.findById(member.getId()).get();
-        assertThat(result).isEqualTo(member);
-    }
-
-    @Test
     public void findByName() {
-        //given
-        Member member = new Member(name, email, password);
-        repository.save(member);
-
-        Member secondMember = new Member(secondName, secondEmail, secondPassword);
-        repository.save(secondMember);
-
         //when
-        Member result = repository.findByName(member.getName()).get();
+        Member result = repository.findByName(name).get();
 
         //then
         assertThat(member).isEqualTo(result);
@@ -63,13 +39,6 @@ class MemoryMemberRepositoryTest {
 
     @Test
     public void findByEmail() {
-        //given
-        Member member = new Member(name, email, password);
-        repository.save(member);
-
-        Member secondMember = new Member(secondName, secondEmail, secondPassword);
-        repository.save(secondMember);
-
         //when
         Member result = repository.findByEmail(member.getEmail()).get();
 
@@ -81,27 +50,17 @@ class MemoryMemberRepositoryTest {
     @Test
     public void findAll() {
         //given
-        Member member = new Member(name, email, password);
-        repository.save(member);
-
-        Member secondMember = new Member(secondName, secondEmail, secondPassword);
-        repository.save(secondMember);
-
-        int expectedSize = 2;
+        int expectedSize = 1;
 
         //when
-        List<Member> result = repository.findAll();
+        int resultSize = repository.findAll().size();
 
         //then
-        assertThat(result.size()).isEqualTo(expectedSize);
+        assertThat(resultSize).isEqualTo(expectedSize);
     }
 
     @Test
     public void findById() {
-        //given
-        Member member = new Member(name, email, password);
-        repository.save(member);
-
         //when
         Member result = repository.findById(member.getId()).get();
 

--- a/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
+++ b/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
@@ -1,9 +1,9 @@
 package com.landvibe.landlog.repository;
 
-import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -13,9 +13,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class MemoryMemberRepositoryTest {
 
-    MemoryMemberRepository repository = new MemoryMemberRepository();
-    MemberForm memberForm1 = new MemberForm("spring1","spring1@spring.com","1234");
-    MemberForm memberForm2 = new MemberForm("spring2","spring2@spring.com","1234");
+    MemoryMemberRepository repository;
+
+    //member1
+    String name1 = "spring1";
+    String email1 = "spring1@spring.com";
+    String password1 = "1234";
+
+    //member2
+    String name2 = "spring2";
+    String email2 = "spring2@spring.com";
+    String password2 = "1234";
+
+    @BeforeEach
+    public void beforeEach() {
+        repository = new MemoryMemberRepository();
+    }
 
     @AfterEach
     public void afterEach() {
@@ -25,7 +38,7 @@ class MemoryMemberRepositoryTest {
     @Test
     void save() {
         //given
-        Member member = new Member(memberForm1);
+        Member member = new Member(name1, email1, password1);
 
         //when
         repository.save(member);
@@ -38,9 +51,9 @@ class MemoryMemberRepositoryTest {
     @Test
     public void findByName() {
         //given
-        Member member1 = new Member(memberForm1);
+        Member member1 = new Member(name1, email1, password1);
         repository.save(member1);
-        Member member2 = new Member(memberForm2);
+        Member member2 = new Member(name2, email2, password2);
         repository.save(member2);
 
         //when
@@ -53,9 +66,9 @@ class MemoryMemberRepositoryTest {
     @Test
     public void findByEmail() {
         //given
-        Member member1 = new Member(memberForm1);
+        Member member1 = new Member(name1, email1, password1);
         repository.save(member1);
-        Member member2 = new Member(memberForm2);
+        Member member2 = new Member(name2, email2, password2);
         repository.save(member2);
 
         //when
@@ -66,13 +79,12 @@ class MemoryMemberRepositoryTest {
     }
 
 
-
     @Test
     public void findAll() {
         //given
-        Member member1 = new Member(memberForm1);
+        Member member1 = new Member(name1, email1, password1);
         repository.save(member1);
-        Member member2 = new Member(memberForm2);
+        Member member2 = new Member(name2, email2, password2);
         repository.save(member2);
 
         //when
@@ -83,9 +95,9 @@ class MemoryMemberRepositoryTest {
     }
 
     @Test
-    public void findById(){
+    public void findById() {
         //given
-        Member member1 = new Member(memberForm1);
+        Member member1 = new Member(name1, email1, password1);
         repository.save(member1);
 
         //when

--- a/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
+++ b/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
@@ -2,10 +2,12 @@ package com.landvibe.landlog.repository;
 
 import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -78,5 +80,18 @@ class MemoryMemberRepositoryTest {
 
         //then
         assertThat(result.size()).isEqualTo(2);
+    }
+
+    @Test
+    public void findById(){
+        //given
+        Member member1 = new Member(memberForm1);
+        repository.save(member1);
+
+        //when
+        Optional<Member> actual = repository.findById(member1.getId());
+
+        //then
+        Assertions.assertThat(actual.get()).isEqualTo(member1);
     }
 }

--- a/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
+++ b/src/test/java/com/landvibe/landlog/repository/MemoryMemberRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.landvibe.landlog.repository;
 
+import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -11,6 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MemoryMemberRepositoryTest {
 
     MemoryMemberRepository repository = new MemoryMemberRepository();
+    MemberForm memberForm1 = new MemberForm("spring1","spring1@spring.com","1234");
+    MemberForm memberForm2 = new MemberForm("spring2","spring2@spring.com","1234");
 
     @AfterEach
     public void afterEach() {
@@ -20,8 +23,7 @@ class MemoryMemberRepositoryTest {
     @Test
     void save() {
         //given
-        Member member = new Member();
-        member.setName("spring");
+        Member member = new Member(memberForm1);
 
         //when
         repository.save(member);
@@ -34,11 +36,9 @@ class MemoryMemberRepositoryTest {
     @Test
     public void findByName() {
         //given
-        Member member1 = new Member();
-        member1.setName("spring1");
+        Member member1 = new Member(memberForm1);
         repository.save(member1);
-        Member member2 = new Member();
-        member2.setName("spring2");
+        Member member2 = new Member(memberForm2);
         repository.save(member2);
 
         //when
@@ -49,13 +49,28 @@ class MemoryMemberRepositoryTest {
     }
 
     @Test
+    public void findByEmail() {
+        //given
+        Member member1 = new Member(memberForm1);
+        repository.save(member1);
+        Member member2 = new Member(memberForm2);
+        repository.save(member2);
+
+        //when
+        Member result = repository.findByEmail("spring1@spring.com").get();
+
+        //then
+        assertThat(result).isEqualTo(member1);
+    }
+
+
+
+    @Test
     public void findAll() {
         //given
-        Member member1 = new Member();
-        member1.setName("spring1");
+        Member member1 = new Member(memberForm1);
         repository.save(member1);
-        Member member2 = new Member();
-        member2.setName("spring2");
+        Member member2 = new Member(memberForm2);
         repository.save(member2);
 
         //when

--- a/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
@@ -2,6 +2,8 @@ package com.landvibe.landlog.service;
 
 import com.landvibe.landlog.controller.LoginForm;
 import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.exception.InvalidEmailException;
+import com.landvibe.landlog.exception.PasswordMismatchException;
 import com.landvibe.landlog.repository.MemoryMemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
@@ -64,7 +66,7 @@ class LoginServiceTest {
 
 
         //when & then
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> loginService.login(errorLoginForm));
+        InvalidEmailException e = assertThrows(InvalidEmailException.class, () -> loginService.login(errorLoginForm));
         Assertions.assertThat(e.getMessage()).isEqualTo("존재하지 않는 이메일입니다.");
     }
 
@@ -77,7 +79,7 @@ class LoginServiceTest {
         LoginForm errorLoginForm = new LoginForm(email, errorPassword);
 
         //when & then
-        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> loginService.login(errorLoginForm));
+        PasswordMismatchException e = assertThrows(PasswordMismatchException.class, () -> loginService.login(errorLoginForm));
         Assertions.assertThat(e.getMessage()).isEqualTo("비밀번호가 일치하지 않습니다.");
     }
 }

--- a/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
@@ -1,0 +1,68 @@
+package com.landvibe.landlog.service;
+
+import com.landvibe.landlog.controller.LoginForm;
+import com.landvibe.landlog.controller.MemberForm;
+import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.repository.MemoryMemberRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginServiceTest {
+
+    MemoryMemberRepository memberRepository = new MemoryMemberRepository();
+    LoginService loginService = new LoginService(memberRepository);
+
+
+    MemberForm memberForm = new MemberForm("spring", "spring1@spring.com", "1234");
+    LoginForm loginForm = new LoginForm("spring1@spring.com", "1234");
+
+    @AfterEach
+    void afterEach() {
+        memberRepository.clearStore();
+    }
+
+    @Test
+    @DisplayName("로그인_정상")
+    void login() {
+        //given
+        Member member = new Member(memberForm); // "spring", "spring1@spring.com", "1234"
+        memberRepository.save(member);
+
+        //when
+        Long memberId = loginService.login(loginForm); // "spring1@spring.com", "1234"
+
+        //then
+        Assertions.assertThat(member.getId()).isEqualTo(memberId);
+    }
+
+    @Test
+    @DisplayName("로그인_비정상_이메일_존재X")
+    void login_whenEmailIsNotExist_Exception() {
+        //given
+        Member member = new Member(memberForm); // "spring", "spring1@spring.com", "1234"
+        memberRepository.save(member);
+        LoginForm errorLoginForm = new LoginForm("error@spring.com", "1234");
+
+
+        //when & then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> loginService.login(errorLoginForm));
+        Assertions.assertThat(e.getMessage()).isEqualTo("존재하지 않는 이메일 입니다.");
+    }
+
+    @Test
+    @DisplayName("로그인_비정상_비밀번호_불일치")
+    void login_whenPasswordIsNotCorrect_Exception() {
+        //given
+        Member member = new Member(memberForm); // "spring", "spring1@spring.com", "1234"
+        memberRepository.save(member);
+        LoginForm errorLoginForm = new LoginForm("spring1@spring.com", "error");
+
+        //when & then
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> loginService.login(errorLoginForm));
+        Assertions.assertThat(e.getMessage()).isEqualTo("비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
@@ -1,11 +1,11 @@
 package com.landvibe.landlog.service;
 
 import com.landvibe.landlog.controller.LoginForm;
-import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
 import com.landvibe.landlog.repository.MemoryMemberRepository;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,12 +13,25 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class LoginServiceTest {
 
-    MemoryMemberRepository memberRepository = new MemoryMemberRepository();
-    LoginService loginService = new LoginService(memberRepository);
+    MemoryMemberRepository memberRepository;
+    LoginService loginService;
+
+    // member, loginForm
+    String name = "spring";
+    String email = "spring@spring.com";
+    String password = "1234";
+    LoginForm loginForm = new LoginForm(email, password);
+
+    //error
+    String errorEmail = "error@spring.com";
+    String errorPassword = "error";
 
 
-    MemberForm memberForm = new MemberForm("spring", "spring1@spring.com", "1234");
-    LoginForm loginForm = new LoginForm("spring1@spring.com", "1234");
+    @BeforeEach
+    void beforeEach() {
+        memberRepository = new MemoryMemberRepository();
+        loginService = new LoginService(memberRepository);
+    }
 
     @AfterEach
     void afterEach() {
@@ -29,11 +42,11 @@ class LoginServiceTest {
     @DisplayName("로그인_정상")
     void login() {
         //given
-        Member member = new Member(memberForm); // "spring", "spring1@spring.com", "1234"
+        Member member = new Member(name, email, password);
         memberRepository.save(member);
 
         //when
-        Long memberId = loginService.login(loginForm); // "spring1@spring.com", "1234"
+        Long memberId = loginService.login(loginForm);
 
         //then
         Assertions.assertThat(member.getId()).isEqualTo(memberId);
@@ -43,9 +56,9 @@ class LoginServiceTest {
     @DisplayName("로그인_비정상_이메일_존재X")
     void login_whenEmailIsNotExist_Exception() {
         //given
-        Member member = new Member(memberForm); // "spring", "spring1@spring.com", "1234"
+        Member member = new Member(name, email, password);
         memberRepository.save(member);
-        LoginForm errorLoginForm = new LoginForm("error@spring.com", "1234");
+        LoginForm errorLoginForm = new LoginForm(errorEmail, password);
 
 
         //when & then
@@ -57,9 +70,9 @@ class LoginServiceTest {
     @DisplayName("로그인_비정상_비밀번호_불일치")
     void login_whenPasswordIsNotCorrect_Exception() {
         //given
-        Member member = new Member(memberForm); // "spring", "spring1@spring.com", "1234"
+        Member member = new Member(name, email, password);
         memberRepository.save(member);
-        LoginForm errorLoginForm = new LoginForm("spring1@spring.com", "error");
+        LoginForm errorLoginForm = new LoginForm(email, errorPassword);
 
         //when & then
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> loginService.login(errorLoginForm));

--- a/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
@@ -63,7 +63,7 @@ class LoginServiceTest {
 
         //when & then
         IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> loginService.login(errorLoginForm));
-        Assertions.assertThat(e.getMessage()).isEqualTo("존재하지 않는 이메일 입니다.");
+        Assertions.assertThat(e.getMessage()).isEqualTo("존재하지 않는 이메일입니다.");
     }
 
     @Test

--- a/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/LoginServiceTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class LoginServiceTest {
 
     MemoryMemberRepository memberRepository;
+    MemberService memberService;
     LoginService loginService;
 
     // member, loginForm
@@ -30,7 +31,8 @@ class LoginServiceTest {
     @BeforeEach
     void beforeEach() {
         memberRepository = new MemoryMemberRepository();
-        loginService = new LoginService(memberRepository);
+        memberService = new MemberService(memberRepository);
+        loginService = new LoginService(memberService);
     }
 
     @AfterEach
@@ -40,7 +42,7 @@ class LoginServiceTest {
 
     @Test
     @DisplayName("로그인_정상")
-    void login() {
+    void login_whenNormalInput_success() {
         //given
         Member member = new Member(name, email, password);
         memberRepository.save(member);

--- a/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
@@ -1,9 +1,9 @@
 package com.landvibe.landlog.service;
 
-import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
 import com.landvibe.landlog.repository.MemoryMemberRepository;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -12,14 +12,25 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MemberServiceTest {
 
-    MemoryMemberRepository memberRepository = new MemoryMemberRepository();
-    MemberService memberService = new MemberService(memberRepository);
+    MemoryMemberRepository memberRepository;
+    MemberService memberService;
 
-    MemberForm memberForm1 = new MemberForm("spring", "spring1@spring.com", "1234");
-    MemberForm memberForm1SameName = new MemberForm("spring", "spring2@spring.com", "1234");
+    //member
+    String name = "spring1";
+    String email = "spring1@spring.com";
+    String password = "1234";
 
-    MemberForm memberForm2 = new MemberForm("spring1", "spring@spring.com", "1234");
-    MemberForm memberForm2SameEmail = new MemberForm("spring2", "spring@spring.com", "1234");
+    //different
+    String differentName = "spring2";
+    String differentEmail = "spring2@spring.com";
+    String differentPassword = "12345";
+
+
+    @BeforeEach
+    public void beforeEach() {
+        memberRepository = new MemoryMemberRepository();
+        memberService = new MemberService(memberRepository);
+    }
 
     @AfterEach
     public void afterEach() {
@@ -29,7 +40,7 @@ class MemberServiceTest {
     @Test
     public void 회원가입() throws Exception {
         //Given
-        Member member = new Member(memberForm1);
+        Member member = new Member(name, email, password);
 
         //When
         Long saveId = memberService.join(member);
@@ -42,26 +53,26 @@ class MemberServiceTest {
     @Test
     public void 중복_이름_예외() throws Exception {
         //Given
-        Member member1 = new Member(memberForm1);
-        Member member2 = new Member(memberForm1SameName);
+        Member member = new Member(name, email, password);
+        Member sameNameMember = new Member(name, differentEmail, differentPassword);
 
         //When
-        memberService.join(member1);
+        memberService.join(member);
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> memberService.join(member2));//예외가 발생해야 한다.
+                () -> memberService.join(sameNameMember));//예외가 발생해야 한다.
         assertThat(e.getMessage()).isEqualTo("이미 존재하는 이름입니다.");
     }
 
     @Test
     public void 중복_이메일_예외() throws Exception {
         //Given
-        Member member1 = new Member(memberForm2);
-        Member member2 = new Member(memberForm2SameEmail);
+        Member member = new Member(name, email, password);
+        Member sameEmailMember = new Member(differentName, email, differentEmail);
 
         //When
-        memberService.join(member1);
+        memberService.join(member);
         IllegalStateException e = assertThrows(IllegalStateException.class,
-                () -> memberService.join(member2));//예외가 발생해야 한다.
+                () -> memberService.join(sameEmailMember));//예외가 발생해야 한다.
         assertThat(e.getMessage()).isEqualTo("이미 존재하는 이메일입니다.");
     }
 }

--- a/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
@@ -16,11 +16,11 @@ class MemberServiceTest {
     MemberService memberService;
     MemoryMemberRepository memberRepository;
 
-    MemberForm memberForm1 = new MemberForm("spring","spring1@spring.com","1234");
-    MemberForm memberForm1SameName = new MemberForm("spring","spring2@spring.com","1234");
+    MemberForm memberForm1 = new MemberForm("spring", "spring1@spring.com", "1234");
+    MemberForm memberForm1SameName = new MemberForm("spring", "spring2@spring.com", "1234");
 
-    MemberForm memberForm2 = new MemberForm("spring1","spring@spring.com","1234");
-    MemberForm memberForm2SameEmail = new MemberForm("spring2","spring@spring.com","1234");
+    MemberForm memberForm2 = new MemberForm("spring1", "spring@spring.com", "1234");
+    MemberForm memberForm2SameEmail = new MemberForm("spring2", "spring@spring.com", "1234");
 
     @BeforeEach
     public void beforeEach() {

--- a/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
@@ -1,6 +1,8 @@
 package com.landvibe.landlog.service;
 
 import com.landvibe.landlog.domain.Member;
+import com.landvibe.landlog.exception.DuplicatedEmailException;
+import com.landvibe.landlog.exception.DuplicatedNameException;
 import com.landvibe.landlog.repository.MemoryMemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,7 +60,7 @@ class MemberServiceTest {
 
         //When
         memberService.join(member);
-        IllegalStateException e = assertThrows(IllegalStateException.class,
+        DuplicatedNameException e = assertThrows(DuplicatedNameException.class,
                 () -> memberService.join(sameNameMember));//예외가 발생해야 한다.
         assertThat(e.getMessage()).isEqualTo("이미 존재하는 이름입니다.");
     }
@@ -71,7 +73,7 @@ class MemberServiceTest {
 
         //When
         memberService.join(member);
-        IllegalStateException e = assertThrows(IllegalStateException.class,
+        DuplicatedEmailException e = assertThrows(DuplicatedEmailException.class,
                 () -> memberService.join(sameEmailMember));//예외가 발생해야 한다.
         assertThat(e.getMessage()).isEqualTo("이미 존재하는 이메일입니다.");
     }

--- a/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
@@ -4,7 +4,6 @@ import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
 import com.landvibe.landlog.repository.MemoryMemberRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,20 +12,14 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class MemberServiceTest {
 
-    MemberService memberService;
-    MemoryMemberRepository memberRepository;
+    MemoryMemberRepository memberRepository = new MemoryMemberRepository();
+    MemberService memberService = new MemberService(memberRepository);
 
     MemberForm memberForm1 = new MemberForm("spring", "spring1@spring.com", "1234");
     MemberForm memberForm1SameName = new MemberForm("spring", "spring2@spring.com", "1234");
 
     MemberForm memberForm2 = new MemberForm("spring1", "spring@spring.com", "1234");
     MemberForm memberForm2SameEmail = new MemberForm("spring2", "spring@spring.com", "1234");
-
-    @BeforeEach
-    public void beforeEach() {
-        memberRepository = new MemoryMemberRepository();
-        memberService = new MemberService(memberRepository);
-    }
 
     @AfterEach
     public void afterEach() {

--- a/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
+++ b/src/test/java/com/landvibe/landlog/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.landvibe.landlog.service;
 
+import com.landvibe.landlog.controller.MemberForm;
 import com.landvibe.landlog.domain.Member;
 import com.landvibe.landlog.repository.MemoryMemberRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +16,12 @@ class MemberServiceTest {
     MemberService memberService;
     MemoryMemberRepository memberRepository;
 
+    MemberForm memberForm1 = new MemberForm("spring","spring1@spring.com","1234");
+    MemberForm memberForm1SameName = new MemberForm("spring","spring2@spring.com","1234");
+
+    MemberForm memberForm2 = new MemberForm("spring1","spring@spring.com","1234");
+    MemberForm memberForm2SameEmail = new MemberForm("spring2","spring@spring.com","1234");
+
     @BeforeEach
     public void beforeEach() {
         memberRepository = new MemoryMemberRepository();
@@ -29,25 +36,39 @@ class MemberServiceTest {
     @Test
     public void 회원가입() throws Exception {
         //Given
-        Member member = new Member();
-        member.setName("hello");
+        Member member = new Member(memberForm1);
+
         //When
         Long saveId = memberService.join(member);
+
         //Then
         Member findMember = memberRepository.findById(saveId).get();
         assertEquals(member.getName(), findMember.getName());
     }
+
     @Test
-    public void 중복_회원_예외() throws Exception {
+    public void 중복_이름_예외() throws Exception {
         //Given
-        Member member1 = new Member();
-        member1.setName("spring");
-        Member member2 = new Member();
-        member2.setName("spring");
+        Member member1 = new Member(memberForm1);
+        Member member2 = new Member(memberForm1SameName);
+
         //When
         memberService.join(member1);
         IllegalStateException e = assertThrows(IllegalStateException.class,
                 () -> memberService.join(member2));//예외가 발생해야 한다.
-        assertThat(e.getMessage()).isEqualTo("이미 존재하는 회원입니다.");
+        assertThat(e.getMessage()).isEqualTo("이미 존재하는 이름입니다.");
+    }
+
+    @Test
+    public void 중복_이메일_예외() throws Exception {
+        //Given
+        Member member1 = new Member(memberForm2);
+        Member member2 = new Member(memberForm2SameEmail);
+
+        //When
+        memberService.join(member1);
+        IllegalStateException e = assertThrows(IllegalStateException.class,
+                () -> memberService.join(member2));//예외가 발생해야 한다.
+        assertThat(e.getMessage()).isEqualTo("이미 존재하는 이메일입니다.");
     }
 }


### PR DESCRIPTION
### 기능 구현
issue 1. 로그인 구현

회원가입 된 회원 정보로 로그인 구현

1. 회원가입 필드 추가
   1. 이메일 / 패스워드 추가 
      1. members/createMemberForm.html 수정 -> email, password 추가
      2. memberForm 객체 수정 -> email, password 추가
      3. member 객체 수정 -> email, password 추가, 생성자 수정(id를 제외하고 객체 생성), set 함수 삭제
      4. memberController.create 함수 수정 -> 객체 생성 수정
      5. memberService.join 의 validate 로직 수정 -> validateDuplicateMember에 email 중복 확인 코드 추가
      6. members/memberList.html 수정 -> email, password 추가
      
2. 홈 화면
   1. Path: /
   2. 로그인 버튼 추가
   3. 클릭 -> /members/login 으로 이동
      => home.html 수정 -> 로그인 버튼 추가(/members/login 으로 보내기)
   
3. 로그인 페이지
   1. Path: /members/login
      1. LoginController 생성 -> @GetMapping("/members/login") 함수 만들어서 loginForm.html과 바인딩
      2. loginForm.html 생성
   

   2. 성공 -> 블로그 리스트 페이지(/blogs?creatorId=1)
      실패 -> 홈(/)
      1. memberService에 login 함수 만들기 
      2. memberService에 validateLogin 함수 만들기
         1. findByEmail해서 null X
         2. password 가 일치
      3. LoginController에 post 방식의 login하는 함수 , 데이터 받아올 form 생성 
         1. memberService.login 활용
         2. 성공시 redirect:/blogs
         3. 실패시 redirect:/
   3. loginForm.html


4. 블로그 페이지
   1. Path: /blogs
      Title: ${name}의 블로그
      1. blogController 추가 (MemberRepository 의존)
         1. blogForm : parameter로 creatorId를 받아옴. name을 찾고, model에 주입해 blogs/blogList.html과 바인딩
      
5. unit test 추가
   1. LoginServiceTest : 추가(정상수행, 이메일 존재 X, 비밀번호 불일치 예외)
   2. MemberServiceTest : "중복_이메일_예외" 추가
   3. MemoryMemberRepositoryTest : 객체 생성 방법 수정(memberForm을 생성자에 주입), findById 추가